### PR TITLE
Bugfix: Add PowerShell Core to the Codespaces image to support using PSRule

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
-    "ghcr.io/devcontainers/features/dotnet:2": {}
+    "ghcr.io/devcontainers/features/dotnet:2": {},
+    "ghcr.io/devcontainers/features/powershell:1": {}
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ To get started, follow the setup instructions at this link: [Setting up your Env
 You'll also need the following tools for this exercise:
 
 1. [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-1. [Git](https://git-scm.com/downloads)
-1. [Docker](https://docs.docker.com/get-docker/)
-1. [.NET 8 SDK](https://dotnet.microsoft.com/download)
-1. [Bicep extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep)
-1. [Docker extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
+2. [Git](https://git-scm.com/downloads)
+3. [Docker](https://docs.docker.com/get-docker/)
+4. [.NET 8 SDK](https://dotnet.microsoft.com/download)
+5. [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell)
+6. [Bicep extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep)
+7. [Docker extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
 
 ### GitHub Codespaces
 


### PR DESCRIPTION
Fixes #3

Add PowerShell Core to the Codespaces dev container to support using PSRule.

* **README.md**
  - Update prerequisites to include PowerShell installation link.
  - Renumber prerequisites to 1-7.
  - Add PowerShell installation as step 5.

* **.devcontainer/devcontainer.json**
  - Add PowerShell Core to the `features` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GitHub-Insight-ANZ-Lab/copilot-challenge-devops-bicep/issues/3?shareId=a424aa98-8e96-4c9e-b3e8-f28ae9d343d2).